### PR TITLE
Allow to send command through data-command-src attribute

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,12 @@ export function registerInputHandlers(termName, instance) {
 
   actions.forEach((a) => {
     a.addEventListener("click", function () {
-      self.socket.emit("instance terminal in", instance.name, this.innerText);
+      let cmd = this.innerText;
+      let dataCmd = this.parentElement.getAttribute("data-command-src");
+      if (dataCmd) {
+          cmd = atob(dataCmd);
+      }
+      self.socket.emit("instance terminal in", instance.name, cmd);
     });
   });
 


### PR DESCRIPTION
`This commit allows to specify a base 64 encoded "data-command-src" attribute to \<pre\> blocks and the SDK will use that information to send to the terminal instead of the actual innerHTML of the element. This is useful in situations where the code block needs to display more information than what it needs to be sent to the terminal (i.e command outputs)

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>