### PR TITLE
Change format on data-upload-src

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwd-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "PWD sdk",
   "main": "dist/index.js",
   "mainReact": "react/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,12 +36,16 @@ export function registerInputHandlers(termName, instance) {
 
     let data;
     if (dataSrc) {
+        let parts = dataSrc.split(":");
         let formData = new FormData();
-        let binData = atob(dataSrc);
+
+        // Decode base64 to ascii
+        let binData = atob(parts[1])
         var blob = new Blob([binData], { type: "text/plain"});
-        formData.append("file", blob);
+        formData.append("file", blob, parts[0]);
         data = formData;
     }
+
     a.addEventListener("click", function () {
         // TODO decide callback action
         self.upload(instance.name, {path, url, data});


### PR DESCRIPTION
Since the Data_URIs doesn't seem to be really useful for this case, this
commit simplifies the format to <filename>:<base64_encoded>

Fixes https://github.com/play-with-docker/play-with-docker/issues/418

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>